### PR TITLE
Add scanning instructions to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PunchedTapeScanner
-An OpenCV program that extracts a data dump from a scanned image of a puched tape.
+An OpenCV program that extracts a data dump from a scanned image of an 8-channel punched tape.
 
 # Compile it
 
@@ -9,6 +9,47 @@ An OpenCV program that extracts a data dump from a scanned image of a puched tap
 >  make  
 
 # Use it
+
+For a typical roll of paper tape with the start of the data on the outside of the roll, unroll the initial part of the tape and place the outer side of the tape against the glass on a flatbed scanner. (If the tape is longer than 256 bytes, you'll need to do multiple scans and extractions, and manually stitch the results together.)
+
+For best results:
+- Place a dark background on top of the tape before scanning.
+- Scan in color at 300 dpi.
+- Crop the image to 1/4 inch on either side of the tape.
+
+The scanned image might look something like this:
+
+	            -----------
+	           / * *      /
+	          /   *      /
+	         /   *      /
+	        /........../
+	start  <     **   <   end
+	        \      *   \
+	         \     **   \
+	          \     *    \
+	           \ * *      \
+	            -----------
+
+To extract the data from the image:
+
+>  ./PunchedTapeScanner img.png output.rom 1
+
+If you accidentally placed the inner side of the tape against the scanner glass, use:
+
+>  ./PunchedTapeScanner img.png output.rom 0
+
+By default, PunchedTapeScanner extracts 8-bit binary data. If your tape is 7-bit ASCII text with a parity bit, change this line:
+
+	unsigned char BIT_MASK = 0xFF;
+
+to:
+
+	unsigned char BIT_MASK = 0x7F;
+
+before compiling.
+
+# Example
 
 There's an example of a scanned punched tape in this repository. The file is called __example/fita_absoluta.2a.0006.96.scan03.png__
 


### PR DESCRIPTION
Since there are multiple ways to orient a punched paper tape on a flatbed scanner, add instructions to README.md.
These instructions have produced the best results for me.

My first attempts produced text that was reversed ("DESREVER") or incorrect (bitwise swapped, e.g. bit 0 swapped with bit 7).

![reader](https://github.com/user-attachments/assets/73987df1-49a5-461d-9735-86d337ac3b0f)
